### PR TITLE
Update for TF2 version 7757534 (2023-01-05)

### DIFF
--- a/addons/sourcemod/gamedata/tf2.buildingoverhaul.txt
+++ b/addons/sourcemod/gamedata/tf2.buildingoverhaul.txt
@@ -239,8 +239,8 @@
 		{
 			"CTFLaserPointer::CanAttack"
 			{
-				"windows" 	"424"
-				"linux" 	"431"
+				"windows" 	"425"
+				"linux" 	"432"
 			}
 			"CTFWeaponBase::SendWeaponAnim"
 			{


### PR DESCRIPTION
I think `CTFWeaponBase::CanAttack` is the only thing that broke this time.  Not seeing any breakages related to the `CTFGameStats` read at least.